### PR TITLE
Add Pop_OS to debian type os list

### DIFF
--- a/static/linux-installer.lisp
+++ b/static/linux-installer.lisp
@@ -7,7 +7,7 @@
                (uiop:read-file-lines #P"/etc/os-release" ) :test #'uiop:string-prefix-p)))
 
 (defparameter *deb-package-systems-ids*
-  '("ubuntu" "debian" "linuxmint"))
+  '("ubuntu" "debian" "linuxmint" "pop"))
 
 (defparameter *arch-package-system-ids*
   '("arch"))


### PR DESCRIPTION
A trivial addition to support Pop OS.

Just tested the script on my laptop.