### PR TITLE
Fix Japanese from 日語 to 日本語 in language selection.

### DIFF
--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -5,7 +5,7 @@ en:
   weight: 100
 
 ja:
-  languageName: "日語"
+  languageName: "日本語"
   contentDir: "content/ja"
   weight: 90
 


### PR DESCRIPTION
日語 is the word for the Japanese language in Chinese.
The word for the Japanese language in Japanese is 日本語