### PR TITLE
docs(tabs): document *enable-tabbar-on-startup* opt-out

### DIFF
--- a/content/en/usage/usage.md
+++ b/content/en/usage/usage.md
@@ -286,6 +286,17 @@ On the GUI version of Lem, you can click on them.
 
 ![](/lem-nice-tabs.png "Lem tabs in the webview version, with a new style added in August of 2025.")
 
+In the webview and server frontends the tab bar is enabled
+automatically at startup. To turn that off, set the
+`*enable-tabbar-on-startup*` variable in your init file
+(`~/.lem/init.lisp`, `~/.config/lem/init.lisp`, or `~/.lemrc`):
+
+```lisp
+(setf lem/tabbar:*enable-tabbar-on-startup* nil)
+```
+
+You can still toggle the tab bar at runtime with `Alt-x toggle-tabbar`.
+
 ### Workspaces (frame-multiplexer)
 
 Lem has a frame multiplexer, aka "workspaces" or "screen


### PR DESCRIPTION
## Summary

Documents the new `lem/tabbar:*enable-tabbar-on-startup*` configuration variable in the existing **Tabs** section of the usage guide.

Followup to lem-project/lem#2166, which exposed the variable so users can disable the auto-enabled tab bar from their init file with a single `setf`.

## What changed

A short paragraph in `content/en/usage/usage.md` after the existing Tabs section, with the snippet to drop into `~/.lemrc` / `init.lisp` and a note that `Alt-x toggle-tabbar` still works at runtime.

## Notes

- Requested by @vindarel in lem-project/lem#2166.
- Did not touch `content/zh-TW/usage/usage.md` — the parallel section there is currently untranslated stub text in English; happy to mirror this paragraph there too if a translator (or a project maintainer) wants the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)